### PR TITLE
[0.x] Minor changes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -76,7 +76,7 @@ dnl --------------------------------------------------------------------
 AX_MSG_BOLD([Checking for required libraries])
 
 AC_CHECK_HEADERS([bsd/string.h], [
-  PKG_CHECK_MODULES([libbsd], [libbsd], [
+  PKG_CHECK_MODULES([libbsd], [libbsd >= 0.8.0], [
     AX_SAVE_FLAGS([ac_cv_libbsd])
 
     AX_APPEND_FLAG([${libbsd_LIBS}], [LIBS])

--- a/configure.ac
+++ b/configure.ac
@@ -15,9 +15,9 @@ dnl implied. See the License for the specific language governing permissions
 dnl and limitations under the License.
 
 AC_PREREQ(2.69)
-AC_INIT([grenache-cli], [0.1.1], [davide@bitfinex.com])
+AC_INIT([grenache-cli], [0.2.0], [davide@bitfinex.com])
 
-AC_SUBST([VERSION], [0.1.1])
+AC_SUBST([VERSION], [0.2.0])
 AC_SUBST([SB], [`$srcdir/shtool echo -n -e %B`])
 AC_SUBST([EB], [`$srcdir/shtool echo -n -e %b`])
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,6 +16,11 @@
 # and limitations under the License.                                       #
 ############################################################################
 
+CFLAGS = $(WARN_CFLAGS)
+LDFLAGS = $(WARN_LDFLAGS)
+CPPFLAGS = -I$(top_srcdir)/include
+
+
 bin_PROGRAMS = \
 grc-keygen \
 grc-sign \
@@ -43,76 +48,40 @@ $(top_srcdir)/ed25519/src/sha512.c \
 $(top_srcdir)/ed25519/src/sign.c \
 $(top_srcdir)/ed25519/src/verify.c
 
-libed25519_la_CFLAGS = \
-$(WARN_CFLAGS)
-
-libed25519_la_LDFLAGS = \
-$(WARN_LDFLAGS)
-
 
 libcommon_la_SOURCES = \
 io.c \
 encode.c
-
-libcommon_la_CPPFLAGS = \
--I$(top_srcdir)/include
-
-libcommon_la_CFLAGS = \
-$(WARN_CFLAGS)
-
-libcommon_la_LDFLAGS = \
-$(WARN_LDFLAGS)
 
 
 grc_keygen_SOURCES = \
 grc-keygen.c
 
 grc_keygen_CPPFLAGS = \
--I$(top_srcdir)/include \
 -I$(top_srcdir)/ed25519/src
 
 grc_keygen_LDADD = \
 libcommon.la \
 libed25519.la
 
-grc_keygen_CFLAGS = \
-$(WARN_CFLAGS)
-
-grc_keygen_LDFLAGS = \
-$(WARN_LDFLAGS)
-
 
 grc_sign_SOURCES = \
 grc-sign.c
 
 grc_sign_CPPFLAGS = \
--I$(top_srcdir)/include \
 -I$(top_srcdir)/ed25519/src
 
 grc_sign_LDADD = \
 libcommon.la \
 libed25519.la
 
-grc_sign_CFLAGS = \
-$(WARN_CFLAGS)
-
-grc_sign_LDFLAGS = \
-$(WARN_LDFLAGS)
-
 
 grc_verify_SOURCES = \
 grc-verify.c
 
 grc_verify_CPPFLAGS = \
--I$(top_srcdir)/include \
 -I$(top_srcdir)/ed25519/src
 
 grc_verify_LDADD = \
 libcommon.la \
 libed25519.la
-
-grc_verify_CFLAGS = \
-$(WARN_CFLAGS)
-
-grc_verify_LDFLAGS = \
-$(WARN_LDFLAGS)


### PR DESCRIPTION
Some minor changes; _grenache-cli_ now requires the version of `libbsd` greater than or equal to **0.8.0**