### PR TITLE
[0.x] Conditionally enable the x86 features check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,9 +15,9 @@ dnl implied. See the License for the specific language governing permissions
 dnl and limitations under the License.
 
 AC_PREREQ(2.69)
-AC_INIT([grenache-cli], [0.2.0], [davide@bitfinex.com])
+AC_INIT([grenache-cli], [0.2.1], [davide@bitfinex.com])
 
-AC_SUBST([VERSION], [0.2.0])
+AC_SUBST([VERSION], [0.2.1])
 AC_SUBST([SB], [`$srcdir/shtool echo -n -e %B`])
 AC_SUBST([EB], [`$srcdir/shtool echo -n -e %b`])
 

--- a/configure.ac
+++ b/configure.ac
@@ -122,7 +122,7 @@ AX_C99_INLINE
 AX_GCC_FUNC_ATTRIBUTE([always_inline])
 AX_COMPILER_FLAGS
 AX_GCC_ARCHFLAG
-AX_CHECK_X86_FEATURES
+AX_ENABLE_X86_FEATURES
 
 dnl --------------------------------------------------------------------
 dnl Checks for library functions.
@@ -186,6 +186,7 @@ AC_MSG_RESULT
 AC_MSG_RESULT
    AX_MSG_OPTION([ Release ................. ], [${ax_is_release}])
    AX_MSG_OPTION([ Debug code .............. ], [${ax_enable_debug}])
+   AX_MSG_OPTION([ Enable x86 features ..... ], [${ax_cv_enable_x86_features}])
    AX_MSG_OPTION([ Warnings ................ ], [${ax_enable_compile_warnings}])
    AX_MSG_OPTION([ Secret Key Descriptor ... ], [${SKEY_FILENO}])
    AX_MSG_OPTION([ Public Key Descriptor ... ], [${PKEY_FILENO}])

--- a/m4/Makefile.am
+++ b/m4/Makefile.am
@@ -44,7 +44,8 @@ ax_gcc_x86_cpuid.m4 \
 ax_compiler_vendor.m4 \
 ax_gcc_archflag.m4 \
 ax_gcc_x86_cpu_supports.m4 \
-ax_check_x86_features.m4
+ax_check_x86_features.m4 \
+ax_enable_x86_features.m4
 
 MAINTAINERCLEANFILES = \
 libtool.m4 \

--- a/m4/ax_enable_x86_features.m4
+++ b/m4/ax_enable_x86_features.m4
@@ -1,0 +1,26 @@
+dnl @synopsis AX_ENABLE_X86_FEATURES([foo], [bar])
+dnl
+dnl Macro to conditionally enable the x86 features check.
+dnl
+dnl Examples:
+dnl    AX_ENABLE_X86_FEATURES
+dnl    AX_ENABLE_X86_FEATURES([foo], [bar])
+dnl
+dnl @category Misc
+dnl @author Davide Scola <davide@bitfinex.com>
+dnl @version 2017-11-09
+dnl @license AllPermissive
+
+AC_DEFUN([AX_ENABLE_X86_FEATURES], [
+  AC_ARG_ENABLE([x86-features], AC_HELP_STRING([--enable-x86-features],
+    [Enable the x86 features check @<:@default=yes@:>@]),
+    [ax_cv_enable_x86_features="${enableval}"], [ax_cv_enable_x86_features='yes'])
+
+  AC_MSG_CHECKING([whether you want to enable the x86 features check])
+
+  AS_IF([test "x${ax_cv_enable_x86_features}" = 'xyes'], [
+    AC_MSG_RESULT([yes])
+    AX_CHECK_X86_FEATURES([$1], [$2])], [
+    AC_MSG_RESULT([no])
+  ])
+])dnl AX_ENABLE_X86_FEATURES

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,9 +16,9 @@
 # and limitations under the License.                                       #
 ############################################################################
 
-CFLAGS = $(WARN_CFLAGS)
-LDFLAGS = $(WARN_LDFLAGS)
-CPPFLAGS = -I$(top_srcdir)/include
+CFLAGS += $(WARN_CFLAGS)
+LDFLAGS += $(WARN_LDFLAGS)
+CPPFLAGS += -I$(top_srcdir)/include
 
 
 bin_PROGRAMS = \


### PR DESCRIPTION
This change makes `grenache-cli` also releasable in _binary_ form