### PR TITLE
[0.x] Better entropy

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -102,6 +102,7 @@ dnl --------------------------------------------------------------------
 AX_MSG_BOLD([Checking for required header files])
 
 AC_HEADER_STDC
+AC_CHECK_HEADERS([sys/random.h])
 AC_CHECK_HEADERS([fcntl.h unistd.h], [], [
   AC_MSG_ERROR([missing $ac_header vital header file])
 ])
@@ -128,6 +129,10 @@ dnl --------------------------------------------------------------------
 dnl Checks for library functions.
 dnl --------------------------------------------------------------------
 AX_MSG_BOLD([Checking for required library functions])
+
+AC_CHECK_FUNCS([getentropy], [
+  CPPFLAGS="-DED25519_NO_SEED ${CPPFLAGS}"
+])
 
 AC_CHECK_FUNCS([explicit_bzero], [], [
   AC_MSG_ERROR([missing $ac_func vital function])
@@ -180,6 +185,7 @@ AC_MSG_RESULT
 AC_MSG_RESULT
    AX_MSG_OPTION([Functions :])
 AC_MSG_RESULT
+   AX_MSG_OPTION([ getentropy .............. ], [${ac_cv_func_getentropy}])
    AX_MSG_OPTION([ explicit_bzero .......... ], [${ac_cv_func_explicit_bzero}])
 AC_MSG_RESULT
    AX_MSG_OPTION([Functionalities :])

--- a/configure.ac
+++ b/configure.ac
@@ -15,9 +15,9 @@ dnl implied. See the License for the specific language governing permissions
 dnl and limitations under the License.
 
 AC_PREREQ(2.69)
-AC_INIT([grenache-cli], [0.2.1], [davide@bitfinex.com])
+AC_INIT([grenache-cli], [0.3.0], [davide@bitfinex.com])
 
-AC_SUBST([VERSION], [0.2.1])
+AC_SUBST([VERSION], [0.3.0])
 AC_SUBST([SB], [`$srcdir/shtool echo -n -e %B`])
 AC_SUBST([EB], [`$srcdir/shtool echo -n -e %b`])
 

--- a/src/grc-keygen.c
+++ b/src/grc-keygen.c
@@ -35,6 +35,10 @@
 # include <string.h>
 #endif
 
+#ifdef HAVE_SYS_RANDOM_H
+# include <sys/random.h>
+#endif
+
 #include <ed25519.h>
 #include "common.h"
 #include "io.h"
@@ -70,7 +74,11 @@ int main(void) {
     exit(EXIT_FAILURE);
   }
 
+#ifdef HAVE_GETENTROPY
+  if (getentropy(seed, ED25519_SEED_SIZE) != ED25519_SEED_SIZE) {
+#else
   if (ed25519_create_seed(seed) != 0) {
+#endif
 #if !defined(NDEBUG)
     (void) fprintf(stderr, "error: cannot initialize ed25519 seeder.\n");
 #endif


### PR DESCRIPTION
This change causes `grenache-cli` to use _getentropy_ when available