### PR TITLE
[0.x] Force user agent

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,9 +15,9 @@ dnl implied. See the License for the specific language governing permissions
 dnl and limitations under the License.
 
 AC_PREREQ(2.69)
-AC_INIT([grenache-cli], [0.3.0], [davide@bitfinex.com])
+AC_INIT([grenache-cli], [0.3.1], [davide@bitfinex.com])
 
-AC_SUBST([VERSION], [0.3.0])
+AC_SUBST([VERSION], [0.3.1])
 AC_SUBST([SB], [`$srcdir/shtool echo -n -e %B`])
 AC_SUBST([EB], [`$srcdir/shtool echo -n -e %b`])
 

--- a/src/grenache-get.in
+++ b/src/grenache-get.in
@@ -124,7 +124,7 @@ do
     exit 1
   }
 
-  JSON="$(@CURL@ -qK "${HOME}/.grenache-cli/grenache-cli.conf" "http${TLS:+s}://${HOSTNAME}:${PORT}/get" < <( \
+  JSON="$(@CURL@ -qK "${HOME}/.grenache-cli/grenache-cli.conf" -A '@PACKAGE@/@PACKAGE_VERSION@' "http${TLS:+s}://${HOSTNAME}:${PORT}/get" < <( \
     @JQ@ -cnM \
       --arg 'data' "${hash}" \
       --arg 'rid' "$(@UUIDGEN@)" \

--- a/src/grenache-keygen.in
+++ b/src/grenache-keygen.in
@@ -71,7 +71,6 @@ exec {debug}>>/dev/null
 #
 silent
 compress
-user-agent "@PACKAGE@/@PACKAGE_VERSION@"
 
 #
 # Request

--- a/src/grenache-put.in
+++ b/src/grenache-put.in
@@ -207,7 +207,7 @@ ARGUMENTS=(
 }
 
 HASH="$(@JQ@ -cMr '.' < <(
-  @CURL@ -qK "${HOME}/.grenache-cli/grenache-cli.conf" "http${TLS:+s}://${HOSTNAME}:${PORT}/put" < <( \
+  @CURL@ -qK "${HOME}/.grenache-cli/grenache-cli.conf" -A '@PACKAGE@/@PACKAGE_VERSION@' "http${TLS:+s}://${HOSTNAME}:${PORT}/put" < <( \
     @JQ@ -cnM \
       "${ARGUMENTS[@]}" \
       --arg 'rid' "$(@UUIDGEN@)" \


### PR DESCRIPTION
This change causes `grenache-cli` to impose the user agent string