### PR TITLE
[0.x] Minor changes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,8 +37,7 @@ DISTCLEANFILES = \
 config.h.in~
 
 MAINTAINERCLEANFILES = \
-$(DISTCLEANFILES) \
-README
+$(DISTCLEANFILES)
 
 dist-hook: dist-ChangeLog
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -29,7 +29,9 @@ EXTRA_DIST = \
 LICENSE \
 README.md \
 autogen.sh \
-shtool
+shtool \
+ed25519/readme.md \
+ed25519/license.txt
 
 DISTCLEANFILES = \
 config.h.in~
@@ -39,8 +41,6 @@ $(DISTCLEANFILES) \
 README
 
 dist-hook: dist-ChangeLog
-	cp -fpR $(top_srcdir)/ed25519 $(distdir)
-	$(RM) -rf $(distdir)/ed25519/.git
 
 maintainer-clean-local: maintainer-clean-local-check
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -26,7 +26,7 @@ case "${1}" in
   ;;
   * )
     autoreconf --force --install --include 'm4'
-    [[ -x shtool ]] || shtoolize -q 'echo'
     [[ -d autom4te.cache ]] && rm -rf autom4te.cache
+    [[ -x shtool ]] || PERL5OPT='-M-warnings=deprecated' shtoolize -q 'echo'
   ;;
 esac

--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,7 @@ AC_CONFIG_SRCDIR([include/io.h])
 AC_CONFIG_HEADERS([config.h])
 
 AC_CANONICAL_HOST
-AM_INIT_AUTOMAKE([foreign no-dist-gzip dist-xz])
+AM_INIT_AUTOMAKE([foreign no-dist-gzip dist-xz subdir-objects])
 AM_EXTRA_RECURSIVE_TARGETS([install-man])
 
 AX_IS_RELEASE([git-directory])

--- a/include/common.h
+++ b/include/common.h
@@ -24,10 +24,10 @@
 #ifdef HAVE_C99_INLINE
 # define INLINE inline
 #else
-# define INLINE static inline
+# define INLINE
 #endif
 
-#ifdef HAVE_FUNC_ATTRIBUTE_ALWAYS_INLINE
+#if defined(HAVE_C99_INLINE) && defined(HAVE_FUNC_ATTRIBUTE_ALWAYS_INLINE)
 # define ALWAYS_INLINE __attribute__ ((__always_inline__))
 #else
 # define ALWAYS_INLINE

--- a/m4/ax_c99_inline.m4
+++ b/m4/ax_c99_inline.m4
@@ -12,6 +12,10 @@
 #   and "extern inline" correctly. An application may replace "inline" with
 #   "static inline" as a workaround for older compilers.
 #
+#   Note: a slightly modified version by Davide Scola <davide@bitfinex.com>
+#         - fix a warning with newer versions of autoconf (for more details
+#           see https://autotools.io/forwardporting/autoconf.html)
+#
 # LICENSE
 #
 #   Copyright (c) 2009 Michael McMaster <email@michaelmcmaster.name>
@@ -35,10 +39,10 @@ AC_DEFUN([AX_C99_INLINE], [
 	dnl	GCC versions before 4.3 would output the inline functions into all
 	dnl	translation units that could require the definition.
 	AC_LINK_IFELSE(
-		AC_LANG_SOURCE([
+		[AC_LANG_SOURCE([
 			inline void* foo() { foo(); return &foo; }
 			int main() { return foo() != 0;}
-			]),
+			])],
 
 		dnl the invalid source compiled, so the inline keyword does not work
 		dnl correctly.
@@ -46,10 +50,10 @@ AC_DEFUN([AX_C99_INLINE], [
 
 		dnl Secondary test of valid source.
 		AC_LINK_IFELSE(
-			AC_LANG_SOURCE([
+			[AC_LANG_SOURCE([
 				extern inline void* foo() { foo(); return &foo; }
 				int main() { return foo() != 0;}
-				]),
+				])],
 
 			AC_MSG_RESULT([yes])
 			AC_DEFINE([HAVE_C99_INLINE], [1],

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -39,23 +39,23 @@ libcommon.la
 
 
 libed25519_la_SOURCES = \
-$(top_srcdir)/ed25519/src/add_scalar.c \
-$(top_srcdir)/ed25519/src/ed25519.h \
-$(top_srcdir)/ed25519/src/fe.h \
-$(top_srcdir)/ed25519/src/fe.c \
-$(top_srcdir)/ed25519/src/fixedint.h \
-$(top_srcdir)/ed25519/src/ge.h \
-$(top_srcdir)/ed25519/src/ge.c \
-$(top_srcdir)/ed25519/src/key_exchange.c \
-$(top_srcdir)/ed25519/src/keypair.c \
-$(top_srcdir)/ed25519/src/precomp_data.h \
-$(top_srcdir)/ed25519/src/sc.h \
-$(top_srcdir)/ed25519/src/sc.c \
-$(top_srcdir)/ed25519/src/seed.c \
-$(top_srcdir)/ed25519/src/sha512.h \
-$(top_srcdir)/ed25519/src/sha512.c \
-$(top_srcdir)/ed25519/src/sign.c \
-$(top_srcdir)/ed25519/src/verify.c
+../ed25519/src/add_scalar.c \
+../ed25519/src/ed25519.h \
+../ed25519/src/fe.h \
+../ed25519/src/fe.c \
+../ed25519/src/fixedint.h \
+../ed25519/src/ge.h \
+../ed25519/src/ge.c \
+../ed25519/src/key_exchange.c \
+../ed25519/src/keypair.c \
+../ed25519/src/precomp_data.h \
+../ed25519/src/sc.h \
+../ed25519/src/sc.c \
+../ed25519/src/seed.c \
+../ed25519/src/sha512.h \
+../ed25519/src/sha512.c \
+../ed25519/src/sign.c \
+../ed25519/src/verify.c
 
 
 libcommon_la_SOURCES = \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -40,12 +40,19 @@ libcommon.la
 
 libed25519_la_SOURCES = \
 $(top_srcdir)/ed25519/src/add_scalar.c \
+$(top_srcdir)/ed25519/src/ed25519.h \
+$(top_srcdir)/ed25519/src/fe.h \
 $(top_srcdir)/ed25519/src/fe.c \
+$(top_srcdir)/ed25519/src/fixedint.h \
+$(top_srcdir)/ed25519/src/ge.h \
 $(top_srcdir)/ed25519/src/ge.c \
 $(top_srcdir)/ed25519/src/key_exchange.c \
 $(top_srcdir)/ed25519/src/keypair.c \
+$(top_srcdir)/ed25519/src/precomp_data.h \
+$(top_srcdir)/ed25519/src/sc.h \
 $(top_srcdir)/ed25519/src/sc.c \
 $(top_srcdir)/ed25519/src/seed.c \
+$(top_srcdir)/ed25519/src/sha512.h \
 $(top_srcdir)/ed25519/src/sha512.c \
 $(top_srcdir)/ed25519/src/sign.c \
 $(top_srcdir)/ed25519/src/verify.c


### PR DESCRIPTION
To continue supporting older versions of _automake_ still used by some OSes, a workaround has been made to deal with [bug#13928](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=13928); in the near future, _grenache-cli_ will require at least [version 1.16](https://lists.gnu.org/archive/html/info-gnu/2018-02/msg00008.html). Also, please note that the macro [ax_c99_inline.m4](https://www.gnu.org/software/autoconf-archive/ax_c99_inline.html) has been slightly modified to fix a warning with [newer versions of autoconf](https://autotools.io/forwardporting/autoconf.html)