### PR TITLE
[0.x] Autoconf updates

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -25,7 +25,7 @@ case "${1}" in
     find . -type f -name 'Makefile.in' -print0 | xargs -r0 rm -f
   ;;
   * )
-    autoreconf --force --install --include 'm4'
+    autoreconf --force --install --warnings=all --include 'm4'
     [[ -d autom4te.cache ]] && rm -rf autom4te.cache
     [[ -x shtool ]] || PERL5OPT='-M-warnings=deprecated' shtoolize -q 'echo'
   ;;

--- a/configure.ac
+++ b/configure.ac
@@ -57,7 +57,6 @@ AM_PROG_CC_C_O
 AC_PROG_INSTALL
 AC_PROG_LN_S
 AC_PROG_MAKE_SET
-AC_PROG_LIBTOOL
 AC_PROG_AWK
 AM_MISSING_PROG([HELP2MAN], [help2man])
 
@@ -103,7 +102,6 @@ dnl Checks for header files.
 dnl --------------------------------------------------------------------
 AX_MSG_BOLD([Checking for required header files])
 
-AC_HEADER_STDC
 AC_CHECK_HEADERS([sys/random.h])
 AC_CHECK_HEADERS([fcntl.h stdint.h unistd.h], [], [
   AC_MSG_ERROR([missing $ac_header vital header file])

--- a/configure.ac
+++ b/configure.ac
@@ -144,7 +144,7 @@ dnl Checks for user defined options.
 dnl --------------------------------------------------------------------
 AX_MSG_BOLD([Checking user defined options])
 
-AC_ARG_ENABLE([x86-features], AC_HELP_STRING([--enable-x86-features],
+AC_ARG_ENABLE([x86-features], AS_HELP_STRING([--enable-x86-features],
   [Enable the x86 features check @<:@default=yes@:>@]),
   [ax_cv_enable_x86_features="${enableval}"], [ax_cv_enable_x86_features='yes'])
 

--- a/configure.ac
+++ b/configure.ac
@@ -14,8 +14,8 @@ dnl WITHOUT  WARRANTIES  OR  CONDITIONS  OF  ANY  KIND,  either  express  or
 dnl implied. See the License for the specific language governing permissions
 dnl and limitations under the License.
 
-AC_PREREQ(2.69)
-AC_INIT([grenache-cli], [0.7.1], [davide@bitfinex.com])
+AC_PREREQ([2.69])
+AC_INIT([grenache-cli],[0.7.1],[davide@bitfinex.com])
 
 AC_SUBST([VERSION], [0.7.1])
 AC_SUBST([SB], [`$srcdir/shtool echo -n -e %B`])
@@ -105,7 +105,7 @@ AX_MSG_BOLD([Checking for required header files])
 
 AC_HEADER_STDC
 AC_CHECK_HEADERS([sys/random.h])
-AC_CHECK_HEADERS([fcntl.h unistd.h], [], [
+AC_CHECK_HEADERS([fcntl.h stdint.h unistd.h], [], [
   AC_MSG_ERROR([missing $ac_header vital header file])
 ])
 
@@ -135,7 +135,7 @@ AC_CHECK_FUNCS([getentropy], [
   CPPFLAGS="-DED25519_NO_SEED ${CPPFLAGS}"
 ])
 
-AC_CHECK_FUNCS([explicit_bzero], [], [
+AC_CHECK_FUNCS([explicit_bzero select], [], [
   AC_MSG_ERROR([missing $ac_func vital function])
 ])
 

--- a/m4/ax_c99_inline.m4
+++ b/m4/ax_c99_inline.m4
@@ -15,6 +15,7 @@
 #   Note: a slightly modified version by Davide Scola <davide@bitfinex.com>
 #         - fix a warning with newer versions of autoconf (for more details
 #           see https://autotools.io/forwardporting/autoconf.html)
+#         - replaced obsolete macro `AC_PROG_CC_C99' with `AC_PROG_CC'
 #
 # LICENSE
 #
@@ -29,7 +30,7 @@
 
 AC_DEFUN([AX_C99_INLINE], [
 	AC_MSG_CHECKING([whether the compiler supports C99 inline functions])
-	AC_REQUIRE([AC_PROG_CC_C99])
+	AC_REQUIRE([AC_PROG_CC])
 
 	AC_LANG_PUSH([C])
 

--- a/m4/ax_define_descriptor.m4
+++ b/m4/ax_define_descriptor.m4
@@ -17,7 +17,7 @@ AC_DEFUN([AX_DEFINE_DESCRIPTOR], [
   AS_LITERAL_IF([$2], [], [AC_FATAL([$0: requires literal arguments])])
   AS_LITERAL_IF([$3], [], [AC_FATAL([$0: requires literal arguments])])
 
-  AC_ARG_WITH(m4_tolower($1), AC_HELP_STRING(m4_tolower(--with-$1),
+  AC_ARG_WITH(m4_tolower($1), AS_HELP_STRING(m4_tolower(--with-$1),
     [Set the $2 file descriptor @<:@default=$3@:>@]),
     ac_cv_[]m4_tolower($1)="${withval:-yes}", ac_cv_[]m4_tolower($1)="$3")
 

--- a/m4/ax_define_size.m4
+++ b/m4/ax_define_size.m4
@@ -17,7 +17,7 @@ AC_DEFUN([AX_DEFINE_SIZE], [
   AS_LITERAL_IF([$2], [], [AC_FATAL([$0: requires literal arguments])])
   AS_LITERAL_IF([$3], [], [AC_FATAL([$0: requires literal arguments])])
 
-  AC_ARG_WITH(m4_tolower($1), AC_HELP_STRING(m4_tolower(--with-$1),
+  AC_ARG_WITH(m4_tolower($1), AS_HELP_STRING(m4_tolower(--with-$1),
     [Set the $2 size in bytes @<:@default=$3@:>@]),
     ac_cv_[]m4_tolower($1)="${withval:-yes}", ac_cv_[]m4_tolower($1)="$3")
 

--- a/m4/ax_gcc_x86_cpu_supports.m4
+++ b/m4/ax_gcc_x86_cpu_supports.m4
@@ -27,6 +27,10 @@
 #   See also AX_CHECK_X86_FEATURES, which checks all the possible
 #   instruction set and export the corresponding CFLAGS.
 #
+#   Note: a slightly modified version by Davide Scola <davide@bitfinex.com>
+#         - default case  during cross-compilation for  the `AC_RUN_IFELSE'
+#           macro has been added
+#
 # LICENSE
 #
 #   Copyright (c) 2016 Felix Chern <idryman@gmail.com>
@@ -68,6 +72,7 @@ AC_DEFUN_ONCE([_AX_GCC_X86_CPU_INIT],
         [__builtin_cpu_init ();])
       ],
       [ax_cv_gcc_check_x86_cpu_init=yes],
+      [ax_cv_gcc_check_x86_cpu_init=no],
       [ax_cv_gcc_check_x86_cpu_init=no])])
   AC_LANG_POP([C])
   AS_IF([test "X$ax_cv_gcc_check_x86_cpu_init" = "Xno"],
@@ -89,6 +94,7 @@ AC_DEFUN([AX_GCC_X86_CPU_SUPPORTS],
          return 1;
         ])],
         [gcc_x86_feature=yes],
+        [gcc_x86_feature=no],
         [gcc_x86_feature=no]
      )]
    )


### PR DESCRIPTION
This set of changes is useful to avoid some warning messages with newer versions of autoconf (_> 2.69_)